### PR TITLE
Entry status in lua entry

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -114,7 +114,8 @@ L_filters = {
     small = function(entry) return entry.size < 1024 * 1024 end,
     me = function(entry) 
         return entry.owner == user -- the user variable is gotten from os.getenv
-    end
+    end,
+    changed = function(entry) return entry.git_status ~= "" end
 }
 ```
 
@@ -191,6 +192,14 @@ Where `entry` is a table with the following keys:
     - `p`: Named pipe (fifo)
     - `s`: Socket
     - `-`: File
+- `git_status`: The git status of the entry
+    - If there is no status for the entry it will be set to `""`
+    - The values returned could be (uppercase letters are staged, 
+    lowercase letters are not staged):
+        - `A` = added
+        - `M` = modified
+        - `R` = renamed
+        - `T` = type changed
 
 The `longest_name` is the length of the longest name in the directory. This
 could be used to align the output.

--- a/include/cli.h
+++ b/include/cli.h
@@ -5,7 +5,7 @@
 #include <git2/types.h>
 #include <stdio.h>
 
-#define LASER_VERSION "1.4.4"
+#define LASER_VERSION "1.4.5"
 
 typedef struct laser_opts
 {

--- a/lua/filters.lua
+++ b/lua/filters.lua
@@ -6,5 +6,6 @@ L_filters = {
     small = function(entry) return entry.size < 1024 * 1024 end,
     me = function(entry)
         return entry.owner == user
-    end
+    end,
+    changed = function(entry) return entry.git_status ~= "" end
 }

--- a/src/laser.c
+++ b/src/laser.c
@@ -71,7 +71,8 @@ void laser_print_long_entry(struct laser_dirent *entry, const char *color,
                                                    : "-");
     lua_setfield(L, -2, "type");
 
-    lua_pushstring(L, (char[]){entry->git_status, 0});
+    lua_pushstring(
+        L, (char[]){entry->git_status == ' ' ? 0 : entry->git_status, 0});
     lua_setfield(L, -2, "git_status");
 
     lua_pushinteger(L, longest_ownername);
@@ -178,6 +179,9 @@ void laser_process_entries(laser_opts opts, int depth, int max_depth,
 
         // default status to ' '
         entry->git_status = ' ';
+        if (opts.show_git->show_git_status)
+            lgit_getGitStatus(opts, entry, full_path);
+
         if (opts.show_git->show_git_status)
             lgit_getGitStatus(opts, entry, full_path);
 

--- a/src/lua_filters.c
+++ b/src/lua_filters.c
@@ -30,6 +30,10 @@ int lua_filters_apply(laser_opts opts, struct laser_dirent *entry)
                       : S_ISSOCK(entry->s.st_mode) ? "s"
                                                    : "-");
     lua_setfield(L, -2, "type");
+
+    lua_pushstring(L, (char[]){entry->git_status, 0});
+    lua_setfield(L, -2, "git_status");
+
     for (int i = 0; i < opts.filter_count; i++)
     {
         lua_getfield(L, -2, opts.filters[i]);

--- a/src/lua_filters.c
+++ b/src/lua_filters.c
@@ -31,7 +31,8 @@ int lua_filters_apply(laser_opts opts, struct laser_dirent *entry)
                                                    : "-");
     lua_setfield(L, -2, "type");
 
-    lua_pushstring(L, (char[]){entry->git_status, 0});
+    lua_pushstring(
+        L, (char[]){entry->git_status == ' ' ? 0 : entry->git_status, 0});
     lua_setfield(L, -2, "git_status");
 
     for (int i = 0; i < opts.filter_count; i++)


### PR DESCRIPTION
Entry status can now be used from the entry table in lua.
A new default filter is added

```lua
changed = function(entry) return entry.git_status ~= "" end
```