### PR TITLE
Fix redirection of output to not show colors by default

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -43,7 +43,7 @@ you can do with a blank `lsr.lua` file.
 
 ### Constants
 
-#### `L_colors`
+#### L_colors
 
 You can configure the colors of the different entry types by modifying the
 global `L_colors` table. You can even add glyphs or text as it is just a normal
@@ -67,7 +67,7 @@ L_colors = {
     DOCUMENT = "\x1b[35;3m",
 }
 ```
-#### `L_recursive_max_depth`
+#### L_recursive_max_depth
 
 You can configure the maximum depth of the directory tree by modifying the
 global `L_recursive_max_depth` variable. It defaults to -1 (which means
@@ -78,7 +78,7 @@ a `-rN` you can set the maximum depth to `N` and override the default value.
 L_recursive_max_depth = -1
 ```
 
-#### `L_default_args`
+#### L_default_args
 
 You can configure the default arguments that should be used when running `lsr`
 by creating the global `L_default_args` table. 
@@ -90,8 +90,11 @@ L_default_args = {
     files = true, -- show files
     directories = true, -- show directories
     symlinks = true, -- show symlinks
-    git = false, -- show git status and entries tracked by git
     long = false, -- show long format
+    git = { 
+        status = false, -- show git status
+        ignored = false, -- show git ignored files
+    }, 
 
     filters = {}, -- apply filters defined in `L_filters` 
                     -- (NOTE: the name should be a string)
@@ -99,7 +102,7 @@ L_default_args = {
 
 ```
 
-#### `L_filters`
+#### L_filters
 
 You can configure the default filters by modifying the global table named
 `L_filters`. You can create your own filters by adding a key with the filter name
@@ -139,7 +142,7 @@ L_filters.myotherfilter = function(entry) return false end
 
 There are a few functions you can use to modify the behavior of the program.
 
-#### `L_compare_entries()`
+#### L_compare_entries()
 
 This function is used to sort the entries in the directory. This is by default
 used to add "gravity" to files so that they fall at the bottom of the list. And
@@ -162,7 +165,7 @@ function L_compare_entries(entry1, entry2, entry1_is_dir, entry2_is_dir)
 end
 ```
 
-#### `L_long_format()`
+#### L_long_format()
 
 This function is used to format the entries in long format. This is by default
 used to show the permissions, the size, last modified and owner of the entry.
@@ -222,7 +225,7 @@ function L_long_format(entry, longest_name)
 end
 ```
 
-#### `L_pre_print_entries()`
+#### L_pre_print_entries()
 
 This function is called before the entries are printed. It can be used to add
 anything before the entries are printed. The function takes no arguments, and it

--- a/README.md
+++ b/README.md
@@ -142,6 +142,10 @@ you can directly pass in the flags.
 - `-l` / `--long`  Displays detailed file information, including permissions,
   last modified date, size, and owner.
 
+- `-c` / `--ensure-colors`  Ensures that the output is colorized even if output
+  is redirected to another file than stdout (e.g. `lsr > file.txt` or `lsr |
+  less`).
+
 - `-fmyfilter` / `--filter=myfilter`  Applies a user-defined filter written in
   Lua.  
   - For more information, see [CONFIGURATION.md](CONFIGURATION.md#L_filters).

--- a/include/cli.h
+++ b/include/cli.h
@@ -5,7 +5,7 @@
 #include <git2/types.h>
 #include <stdio.h>
 
-#define LASER_VERSION "1.4.10"
+#define LASER_VERSION "1.5.0"
 
 typedef struct laser_opts
 {

--- a/include/cli.h
+++ b/include/cli.h
@@ -28,6 +28,8 @@ typedef struct laser_opts
     int filter_count;
     const char **filters;
 
+    int ensure_colors;
+
     const char *dir;
     const char *parentDir;
 } laser_opts;

--- a/include/colors.h
+++ b/include/colors.h
@@ -1,6 +1,7 @@
 #ifndef LASER_COLORS_H
 #define LASER_COLORS_H
 
+#include "cli.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -39,7 +40,7 @@ typedef enum laser_color_type
 
 extern laser_color LASER_COLORS[COLOR_COUNT];
 
-void laser_colors_init(void);
+void laser_colors_init(struct laser_opts opts);
 void laser_colors_parseToken(const char *token);
 
 #undef _X

--- a/lua/lsr.lua
+++ b/lua/lsr.lua
@@ -33,7 +33,7 @@ L_default_args = {
     files = true,
     directories = true,
     symlinks = true,
-    git = false,
+    git = { status = false, ignore = false },
     long = false,
     filters = {},
 }

--- a/lua/lsr.lua
+++ b/lua/lsr.lua
@@ -35,5 +35,6 @@ L_default_args = {
     symlinks = true,
     git = { status = false, ignore = false },
     long = false,
+    ensure_colors = false,
     filters = {},
 }

--- a/src/cli.c
+++ b/src/cli.c
@@ -19,6 +19,7 @@ static int completionsset;
     _X("recursive", optional_argument, 0, 'r', "Show in tree format")          \
     _X("filter", required_argument, 0, 'f',                                    \
        "Filter out files using lua filters (L_filters in lsr.lua)")            \
+    _X("ensure-colors", 0, 0, 'c', "Force colored output")                     \
     _X("no-lua", 0, 0, '!',                                                    \
        "Don't use user defined configuration from lsr.lua")                    \
     _X("version", 0, 0, 'v', "Print the current version")                      \
@@ -30,70 +31,14 @@ static int completionsset;
 static const struct option long_args[] = {ARGS_ITER(_X){0, 0, 0, 0}};
 #undef _X
 #define _X(name, a, b, short, description) description,
-static const char *descriptions[] = {
-    ARGS_ITER(_X)
-};
+static const char *descriptions[] = {ARGS_ITER(_X)};
 #undef _X
-
-#define L_DEFAULT_SIMPLE_ARGS(_X)                                              \
-    _X(all, boolean)                                                           \
-    _X(files, boolean)                                                         \
-    _X(directories, boolean)                                                   \
-    _X(symlinks, boolean)                                                      \
-    _X(long, boolean)
-
-#define L_DEFAULT_SIMPLE_ARGS_GET(arg, type)                                   \
-    lua_pushstring(L, #arg);                                                   \
-    lua_gettable(L, -2);                                                       \
-    if (lua_is##type(L, -1))                                                   \
-        *show_##arg = lua_toboolean(L, -1);                                    \
-    lua_pop(L, 1);
 
 static void lua_get_L_default_args(int *show_all, int *show_files,
                                    int *show_directories, int *show_symlinks,
                                    int *show_long,
                                    struct lgit_show_git *show_git,
-                                   const char ***filters, int *filter_count)
-{
-    lua_getglobal(L, "L_default_args");
-    if (!lua_istable(L, -1))
-        return;
-
-    L_DEFAULT_SIMPLE_ARGS(L_DEFAULT_SIMPLE_ARGS_GET)
-
-    lua_pushstring(L, "git");
-    lua_gettable(L, -2);
-    if (lua_istable(L, -1))
-    {
-        lua_pushstring(L, "status");
-        lua_gettable(L, -2);
-        if (lua_isboolean(L, -1))
-            show_git->show_git_status = lua_toboolean(L, -1);
-        lua_pop(L, 1);
-        lua_pushstring(L, "ignored");
-        lua_gettable(L, -2);
-        if (lua_isboolean(L, -1))
-            show_git->hide_git_ignored = lua_toboolean(L, -1);
-        lua_pop(L, 1);
-    }
-    lua_pop(L, 1);
-
-    lua_pushstring(L, "filters");
-    lua_gettable(L, -2);
-    if (lua_istable(L, -1))
-    {
-        lua_pushnil(L);
-        while (lua_next(L, -2) != 0)
-        {
-            (*filters) =
-                realloc(*filters, sizeof(char *) * ((*filter_count) + 1));
-            (*filters)[*filter_count] = strdup(lua_tostring(L, -1));
-            (*filter_count)++;
-            lua_pop(L, 1);
-        }
-    }
-    lua_pop(L, 1);
-}
+                                   const char ***filters, int *filter_count);
 
 #define L_DEFAULT_ARG_TYPES(_X)                                                \
     _X(show_files)                                                             \
@@ -126,6 +71,8 @@ laser_opts laser_cli_parsecmd(int argc, char **argv)
     int filter_count = 0;
     const char **filters = NULL;
 
+    int ensure_colors = 0;
+
     int opt;
 
 #define _X(name) int default_##name;
@@ -142,7 +89,7 @@ laser_opts laser_cli_parsecmd(int argc, char **argv)
     if (lua_isnumber(L, -1))
         recursive_depth = (int)lua_tointeger(L, -1);
 
-    while ((opt = getopt_long(argc, argv, "aFDSG::g::i::r::lvhf::!", long_args,
+    while ((opt = getopt_long(argc, argv, "aFDSG::g::i::r::lcvhf::!", long_args,
                               NULL)) != -1)
     {
         switch (opt)
@@ -197,6 +144,9 @@ laser_opts laser_cli_parsecmd(int argc, char **argv)
                 break;
             case 'l':
                 show_long = 1;
+                break;
+            case 'c':
+                ensure_colors = 1;
                 break;
             case 'v':
                 printf("laser %s\n", LASER_VERSION);
@@ -257,10 +207,11 @@ laser_opts laser_cli_parsecmd(int argc, char **argv)
         }
     }
 
-    return (laser_opts){
-        show_all, show_files, show_directories, show_symlinks,   show_git,
-        git_repo, show_tree,  show_long,        recursive_depth, filter_count,
-        filters,  dir,        .parentDir = dir};
+    return (laser_opts){show_all,      show_files,      show_directories,
+                        show_symlinks, show_git,        git_repo,
+                        show_tree,     show_long,       recursive_depth,
+                        filter_count,  filters,         ensure_colors,
+                        dir,           .parentDir = dir};
 }
 
 void laser_cli_generate_completions(const char *shell)
@@ -383,4 +334,64 @@ void laser_cli_destroy_opts(laser_opts opts)
     for (int i = 0; i < opts.filter_count; i++)
         free((void *)opts.filters[i]);
     free(opts.filters);
+}
+
+// ------------------------- helper function decl -----------------------------
+#define L_DEFAULT_SIMPLE_ARGS(_X)                                              \
+    _X(all, boolean)                                                           \
+    _X(files, boolean)                                                         \
+    _X(directories, boolean)                                                   \
+    _X(symlinks, boolean)                                                      \
+    _X(long, boolean)
+
+#define L_DEFAULT_SIMPLE_ARGS_GET(arg, type)                                   \
+    lua_pushstring(L, #arg);                                                   \
+    lua_gettable(L, -2);                                                       \
+    if (lua_is##type(L, -1))                                                   \
+        *show_##arg = lua_toboolean(L, -1);                                    \
+    lua_pop(L, 1);
+static void lua_get_L_default_args(int *show_all, int *show_files,
+                                   int *show_directories, int *show_symlinks,
+                                   int *show_long,
+                                   struct lgit_show_git *show_git,
+                                   const char ***filters, int *filter_count)
+{
+    lua_getglobal(L, "L_default_args");
+    if (!lua_istable(L, -1))
+        return;
+
+    L_DEFAULT_SIMPLE_ARGS(L_DEFAULT_SIMPLE_ARGS_GET);
+
+    lua_pushstring(L, "git");
+    lua_gettable(L, -2);
+    if (lua_istable(L, -1))
+    {
+        lua_pushstring(L, "status");
+        lua_gettable(L, -2);
+        if (lua_isboolean(L, -1))
+            show_git->show_git_status = lua_toboolean(L, -1);
+        lua_pop(L, 1);
+        lua_pushstring(L, "ignored");
+        lua_gettable(L, -2);
+        if (lua_isboolean(L, -1))
+            show_git->hide_git_ignored = lua_toboolean(L, -1);
+        lua_pop(L, 1);
+    }
+    lua_pop(L, 1);
+
+    lua_pushstring(L, "filters");
+    lua_gettable(L, -2);
+    if (lua_istable(L, -1))
+    {
+        lua_pushnil(L);
+        while (lua_next(L, -2) != 0)
+        {
+            (*filters) =
+                realloc(*filters, sizeof(char *) * ((*filter_count) + 1));
+            (*filters)[*filter_count] = strdup(lua_tostring(L, -1));
+            (*filter_count)++;
+            lua_pop(L, 1);
+        }
+    }
+    lua_pop(L, 1);
 }

--- a/src/colors.c
+++ b/src/colors.c
@@ -20,7 +20,7 @@ static void laser_colors_set(const char *key, const char *value)
 void laser_colors_init(struct laser_opts opts)
 {
     int isStdout = isatty(STDOUT_FILENO);
-#define PRINT_COLORS isStdout || opts.ensure_colors
+#define PRINT_COLORS (isStdout || opts.ensure_colors) // dis () is importante 😭
 
 // macro stuff be 🔥
 #define _X(name, val)                                                          \
@@ -29,7 +29,7 @@ void laser_colors_init(struct laser_opts opts)
     LASER_COLORS_ITER(_X);
 #undef _X
 
-    if (!isStdout)
+    if (!PRINT_COLORS)
         return;
 
     lua_getglobal(L, "L_colors");

--- a/src/colors.c
+++ b/src/colors.c
@@ -17,17 +17,15 @@ static void laser_colors_set(const char *key, const char *value)
     }
 }
 
-void laser_colors_init(void)
+void laser_colors_init(struct laser_opts opts)
 {
-    // we ain't printing to stdout so don't do colors
-    // TODO: unless the user specifies a `--ensure-colors` flag
     int isStdout = isatty(STDOUT_FILENO);
+#define PRINT_COLORS isStdout || opts.ensure_colors
 
 // macro stuff be 🔥
 #define _X(name, val)                                                          \
     LASER_COLORS[LASER_COLOR_##name].key = #name;                              \
-    LASER_COLORS[LASER_COLOR_##name].value =                                   \
-        isStdout ? val : ""; // empty of not stdout
+    LASER_COLORS[LASER_COLOR_##name].value = PRINT_COLORS ? val : "";
     LASER_COLORS_ITER(_X);
 #undef _X
 

--- a/src/colors.c
+++ b/src/colors.c
@@ -1,6 +1,7 @@
 #include "colors.h"
 #include "init_lua.h"
 #include <lua.h>
+#include <unistd.h>
 
 laser_color LASER_COLORS[COLOR_COUNT];
 
@@ -16,14 +17,22 @@ static void laser_colors_set(const char *key, const char *value)
     }
 }
 
-// macro stuff be 🔥
-#define _X(name, vaule)                                                        \
-    LASER_COLORS[LASER_COLOR_##name].key = #name;                      \
-    LASER_COLORS[LASER_COLOR_##name].value = vaule;
-
 void laser_colors_init(void)
 {
-    LASER_COLORS_ITER(_X)
+    // we ain't printing to stdout so don't do colors
+    // TODO: unless the user specifies a `--ensure-colors` flag
+    int isStdout = isatty(STDOUT_FILENO);
+
+// macro stuff be 🔥
+#define _X(name, val)                                                          \
+    LASER_COLORS[LASER_COLOR_##name].key = #name;                              \
+    LASER_COLORS[LASER_COLOR_##name].value =                                   \
+        isStdout ? val : ""; // empty of not stdout
+    LASER_COLORS_ITER(_X);
+#undef _X
+
+    if (!isStdout)
+        return;
 
     lua_getglobal(L, "L_colors");
 
@@ -39,4 +48,3 @@ void laser_colors_init(void)
 
     lua_settop(L, 0);
 }
-#undef _X

--- a/src/main.c
+++ b/src/main.c
@@ -55,8 +55,8 @@ int main(int argc, char **argv)
     if (script_to_load != default_script)
         laser_lua_load_script(script_to_load);
 
-    laser_colors_init();
     laser_opts opts = laser_cli_parsecmd(argc, argv);
+    laser_colors_init();
 
     struct stat path_stat;
     if (stat(opts.dir, &path_stat) != 0)

--- a/src/main.c
+++ b/src/main.c
@@ -56,7 +56,7 @@ int main(int argc, char **argv)
         laser_lua_load_script(script_to_load);
 
     laser_opts opts = laser_cli_parsecmd(argc, argv);
-    laser_colors_init();
+    laser_colors_init(opts);
 
     struct stat path_stat;
     if (stat(opts.dir, &path_stat) != 0)


### PR DESCRIPTION
Now the redirection of output dosen't show colors by default. Unless you apply the `--ensure-colors flag` or define the `ensure_colors = true` in the `L_default_args` the redirected output will be colorless.