### PR TITLE
Fix symlink git status issues, and single entry listing issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ build/
 assets/demo-dir
 .cache/
 
+test
+
 compile_commands.json
 
 .quickmarks

--- a/include/cli.h
+++ b/include/cli.h
@@ -4,7 +4,7 @@
 #include <git2/types.h>
 #include <stdio.h>
 
-#define LASER_VERSION "1.7.0"
+#define LASER_VERSION "1.7.1"
 
 typedef struct laser_opts
 {

--- a/src/laser.c
+++ b/src/laser.c
@@ -82,8 +82,7 @@ void laser_process_single_file(laser_opts opts)
     longest_ownername = strlen(ownername); // this has to be the longest name
                                            // cus it be the ownly name
 
-    laser_print_entry(&entry, LASER_COLORS[LASER_COLOR_FILE].value, "", 0, opts,
-                      1);
+    laser_handle_entry(&entry, opts.dir, "", 0, opts, 1);
 
     free(entry.d);
 }

--- a/src/laser.c
+++ b/src/laser.c
@@ -295,13 +295,14 @@ static void laser_handle_entry(struct laser_dirent *entry,
                                    strerror(errno));
 
             ent->s = entry->s;
-            ent->d = malloc(offsetof(struct dirent, d_name) +
-                            strlen(res_string) + 1);
+            ent->d = malloc(sizeof(struct dirent));
             if (ent->d == NULL)
                 laser_logger_fatal(1, "Failed to allocate entry struct: %s",
                                    strerror(errno));
 
             strcpy(ent->d->d_name, res_string);
+
+            ent->git_status = entry->git_status;
 
             laser_print_entry(ent, LASER_COLORS[LASER_COLOR_SYMLINK].value,
                               indent, depth, opts, is_last);
@@ -432,8 +433,9 @@ static void laser_print_entry(struct laser_dirent *entry, const char *color,
 
     printf("%s%s%s%s%s", indent, branch, color, entry->d->d_name,
            LASER_COLORS[LASER_COLOR_RESET].value);
-    if (entry->git_status && entry->git_status != ' ')
-        printf("\x1b[33m [%c]\x1b[0m", entry->git_status);
+    (entry->git_status && entry->git_status != ' ')
+        ? printf("\x1b[33m [%c]\x1b[0m", entry->git_status)
+        : 0;
     printf("\n");
 }
 


### PR DESCRIPTION
These commits adresses some issues with the git status listing of symlinks and the single entry listing. 

* **Symlink entries:** The git status information wouldn't show correctly it would either return empty brackets or nothing at all, now the issue has been fixed, where symlinks alsow shows the git status.
* **Single file listing:** Before these commits if you listed a single entry it would always be treated as a regular file, now single entries are handled correctly and colored and outputed as expected. 


Before:
<img width="589" alt="Screenshot 2025-06-04 at 22 39 23" src="https://github.com/user-attachments/assets/c7ec19c4-834a-4815-9f6f-10daf3a1cf2d" />

After:
<img width="589" alt="Screenshot 2025-06-04 at 22 41 13" src="https://github.com/user-attachments/assets/dcdd2a87-d7ab-4e29-83aa-93d54a94f8be" />
