### PR TITLE
Add submodule git support

### DIFF
--- a/include/cli.h
+++ b/include/cli.h
@@ -19,6 +19,7 @@ typedef struct laser_opts
         int hide_git_ignored;
     } *show_git;
     git_repository *git_repo;
+    const char *git_dir;
 
     int show_recursive;
     int recursive_depth;

--- a/include/cli.h
+++ b/include/cli.h
@@ -4,7 +4,7 @@
 #include <git2/types.h>
 #include <stdio.h>
 
-#define LASER_VERSION "1.7.5"
+#define LASER_VERSION "1.7.7"
 
 typedef struct laser_opts
 {

--- a/include/git/lgit.h
+++ b/include/git/lgit.h
@@ -1,14 +1,11 @@
 #ifndef LASER_GIT_LGIT_H
 #define LASER_GIT_LGIT_H
 
-#include "cli.h"
 #include "laser.h"
 #include <git2.h>
 #include <stdint.h>
 
-void lgit_getGitStatus(laser_opts opts, struct laser_dirent *entry,
-                       const char *full_path);
-void lgit_getDirStatus(laser_opts opts, struct laser_dirent *entry,
+void lgit_getGitStatus(git_repository *repo, struct laser_dirent *entry,
                        const char *full_path);
 
 #endif

--- a/src/cli.c
+++ b/src/cli.c
@@ -225,8 +225,7 @@ laser_opts laser_cli_parsecmd(int argc, char **argv)
 
     if (show_git->show_git_status || show_git->hide_git_ignored)
     {
-        int err = git_repository_open(&git_repo, gitDir);
-        if (err != 0)
+        if (git_repository_open(&git_repo, gitDir) != 0)
         {
             laser_logger_error("couldn't open git repo at '%s'\n", gitDir);
             show_git = 0;
@@ -239,6 +238,7 @@ laser_opts laser_cli_parsecmd(int argc, char **argv)
                         show_symlinks,
                         show_git,
                         git_repo,
+                        gitDir,
                         show_recursive,
                         recursive_depth,
                         show_long,
@@ -365,7 +365,6 @@ void laser_cli_destroy_opts(laser_opts opts)
 {
     if (opts.git_repo)
         git_repository_free(opts.git_repo);
-
     free(opts.show_git);
 
     for (int i = 0; i < opts.filter_count; i++)

--- a/src/git/lgit.c
+++ b/src/git/lgit.c
@@ -1,11 +1,46 @@
 #include "git/lgit.h"
+#include "laser.h"
 #include "logger.h"
 #include <git2/errors.h>
 #include <git2/global.h>
 #include <git2/status.h>
 
-static void lgit_getDirsStatus(laser_opts opts, struct laser_dirent *entry,
-                               const char *full_path)
+static const char *laser_repo_relative(git_repository *repo,
+                                       const char *full_path, char *buffer,
+                                       size_t buffer_size)
+{
+    if (!repo || !full_path || !buffer)
+        return NULL;
+
+    const char *workdir = git_repository_workdir(repo);
+    if (!workdir)
+        return NULL;
+
+    char abs_path[LASER_PATH_MAX];
+    if (full_path[0] != '/')
+    {
+        if (!realpath(full_path, abs_path))
+            return NULL;
+    }
+    else
+    {
+        strncpy(abs_path, full_path, sizeof(abs_path) - 1);
+        abs_path[sizeof(abs_path) - 1] = '\0';
+    }
+
+    size_t root_len = strlen(workdir);
+
+    if (workdir[root_len - 1] != '/')
+        return NULL;
+    if (strncmp(abs_path, workdir, root_len) != 0)
+        return NULL;
+
+    snprintf(buffer, buffer_size, "%s", abs_path + root_len);
+    return buffer;
+}
+
+static void lgit_getDirStatus(git_repository *repo, struct laser_dirent *entry,
+                              const char *full_path)
 {
     entry->git_status = ' ';
 
@@ -14,7 +49,7 @@ static void lgit_getDirsStatus(laser_opts opts, struct laser_dirent *entry,
     status_opts.flags = GIT_STATUS_OPT_INCLUDE_UNTRACKED;
 
     git_status_list *status_list;
-    if (git_status_list_new(&status_list, opts.git_repo, &status_opts) != 0)
+    if (git_status_list_new(&status_list, repo, &status_opts) != 0)
     {
         laser_logger_error("failed to get status list for directory %s\n",
                            full_path);
@@ -43,29 +78,26 @@ static void lgit_getDirsStatus(laser_opts opts, struct laser_dirent *entry,
 }
 
 #define INITIAL_CAPACITY 10
-void lgit_getGitStatus(laser_opts opts, struct laser_dirent *entry,
+void lgit_getGitStatus(git_repository *repo, struct laser_dirent *entry,
                        const char *full_path)
 {
     entry->git_status = ' ';
 
-    // skip the leading "./" cuz libgit dosen't like it
-    if (strncmp(full_path, "./", 2) == 0)
-        full_path += 2;
+    char relative[LASER_PATH_MAX];
 
-    // so... git dosent track dirs, only files
+    if (!laser_repo_relative(repo, full_path, relative, sizeof(relative)))
+        return;
+
     if (entry->d->d_type == DT_DIR)
     {
-        lgit_getDirsStatus(opts, entry, full_path);
+        lgit_getDirStatus(repo, entry, relative);
         return;
     }
 
     unsigned int status;
-    if (git_status_file(&status, opts.git_repo, full_path) != 0)
-    {
-        laser_logger_error("failed to get status for %s\n", full_path);
-        laser_logger_error("%s\n", git_error_last()->message);
+
+    if (git_status_file(&status, repo, relative) != 0)
         return;
-    }
 
     switch (status)
     {
@@ -81,8 +113,6 @@ void lgit_getGitStatus(laser_opts opts, struct laser_dirent *entry,
         case GIT_STATUS_WT_TYPECHANGE:
             entry->git_status = 't';
             break;
-
-            // staged changes
         case GIT_STATUS_INDEX_NEW:
             entry->git_status = 'A';
             break;

--- a/src/laser.c
+++ b/src/laser.c
@@ -127,7 +127,10 @@ static void laser_list_directory(laser_opts opts, int depth)
         return;
 
     laser_opts lopts = opts;
-    git_repository_open(&lopts.git_repo, opts.dir);
+
+    if (opts.show_git->show_git_status &&
+        strncmp(opts.git_dir, opts.dir, strlen(opts.git_dir)) != 0)
+        git_repository_open(&lopts.git_repo, opts.dir);
     if (lopts.git_repo == NULL)
         lopts.git_repo = opts.git_repo;
 
@@ -145,8 +148,9 @@ static void laser_list_directory(laser_opts opts, int depth)
     laser_process_entries(lopts, depth, indent);
 
     free(indent);
-    if (strncmp(opts.dir, opts.git_dir, strlen(opts.git_dir)) != 0)
-        git_repository_free(opts.git_repo);
+
+    if (lopts.git_repo && lopts.git_repo != opts.git_repo)
+        git_repository_free(lopts.git_repo);
 }
 
 static void laser_process_entries(laser_opts opts, int depth, char *indent)


### PR DESCRIPTION
This pr adds support for submodules. A git directory containing submodules will show the statuses of the submodules correctly, and if the recurisve flag is applied (`-r` / `--recursive`) the contents of the submodule will show their status correctly. 